### PR TITLE
removed *_AMP gmm ids

### DIFF
--- a/Western US/Cluster/gmm.xml
+++ b/Western US/Cluster/gmm.xml
@@ -2,9 +2,9 @@
 <GroundMotionModels>
   <!-- This model is an example and for review purposes only -->
   <ModelSet maxDistance="300.0">
-    <Model id="ASK_14_BASIN_AMP" weight="0.25"/>
-    <Model id="BSSA_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CB_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CY_14_BASIN_AMP" weight="0.25"/>
+    <Model id="ASK_14_BASIN" weight="0.25"/>
+    <Model id="BSSA_14_BASIN" weight="0.25"/>
+    <Model id="CB_14_BASIN" weight="0.25"/>
+    <Model id="CY_14_BASIN" weight="0.25"/>
   </ModelSet>
 </GroundMotionModels>

--- a/Western US/Fault/gmm.xml
+++ b/Western US/Fault/gmm.xml
@@ -3,9 +3,9 @@
   <!-- This model is an example and for review purposes only -->
   <Uncertainty values="[0.37, 0.25, 0.4, 0.22, 0.23, 0.36, 0.22, 0.23, 0.33]" weights="[0.185, 0.63, 0.185]"/>
   <ModelSet maxDistance="300.0">
-    <Model id="ASK_14_BASIN_AMP" weight="0.25"/>
-    <Model id="BSSA_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CB_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CY_14_BASIN_AMP" weight="0.25"/>
+    <Model id="ASK_14_BASIN" weight="0.25"/>
+    <Model id="BSSA_14_BASIN" weight="0.25"/>
+    <Model id="CB_14_BASIN" weight="0.25"/>
+    <Model id="CY_14_BASIN" weight="0.25"/>
   </ModelSet>
 </GroundMotionModels>

--- a/Western US/Grid/gmm.xml
+++ b/Western US/Grid/gmm.xml
@@ -3,9 +3,9 @@
   <!-- This model is an example and for review purposes only -->
   <Uncertainty values="[0.37, 0.25, 0.4, 0.22, 0.23, 0.36, 0.22, 0.23, 0.33]" weights="[0.185, 0.63, 0.185]"/>
   <ModelSet maxDistance="300.0">
-    <Model id="ASK_14_BASIN_AMP" weight="0.25"/>
-    <Model id="BSSA_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CB_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CY_14_BASIN_AMP" weight="0.25"/>
+    <Model id="ASK_14_BASIN" weight="0.25"/>
+    <Model id="BSSA_14_BASIN" weight="0.25"/>
+    <Model id="CB_14_BASIN" weight="0.25"/>
+    <Model id="CY_14_BASIN" weight="0.25"/>
   </ModelSet>
 </GroundMotionModels>

--- a/Western US/Interface/gmm.xml
+++ b/Western US/Interface/gmm.xml
@@ -2,8 +2,8 @@
 <GroundMotionModels>
   <!-- This model is an example and for review purposes only -->
   <ModelSet maxDistance="1000.0">
-    <Model id="AM_09_INTERFACE_BASIN_AMP" weight="0.3333"/>
-    <Model id="BCHYDRO_12_INTERFACE_BASIN_AMP" weight="0.3334"/>
-    <Model id="ZHAO_06_INTERFACE_BASIN_AMP" weight="0.3333"/>
+    <Model id="AM_09_INTERFACE_BASIN" weight="0.3333"/>
+    <Model id="BCHYDRO_12_INTERFACE_BASIN" weight="0.3334"/>
+    <Model id="ZHAO_06_INTERFACE_BASIN" weight="0.3333"/>
   </ModelSet>
 </GroundMotionModels>

--- a/Western US/Slab/gmm.xml
+++ b/Western US/Slab/gmm.xml
@@ -2,7 +2,7 @@
 <GroundMotionModels>
   <!-- This model is an example and for review purposes only -->
   <ModelSet maxDistance="300.0">
-    <Model id="BCHYDRO_12_SLAB_BASIN_AMP" weight="0.5"/>
-    <Model id="ZHAO_06_SLAB_BASIN_AMP" weight="0.5"/>
+    <Model id="BCHYDRO_12_SLAB_BASIN" weight="0.5"/>
+    <Model id="ZHAO_06_SLAB_BASIN" weight="0.5"/>
   </ModelSet>
 </GroundMotionModels>

--- a/Western US/System/gmm.xml
+++ b/Western US/System/gmm.xml
@@ -3,9 +3,9 @@
   <!-- This model is an example and for review purposes only -->
   <Uncertainty values="[0.37, 0.25, 0.4, 0.22, 0.23, 0.36, 0.22, 0.23, 0.33]" weights="[0.185, 0.63, 0.185]"/>
   <ModelSet maxDistance="300.0">
-    <Model id="ASK_14_BASIN_AMP" weight="0.25"/>
-    <Model id="BSSA_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CB_14_BASIN_AMP" weight="0.25"/>
-    <Model id="CY_14_BASIN_AMP" weight="0.25"/>
+    <Model id="ASK_14_BASIN" weight="0.25"/>
+    <Model id="BSSA_14_BASIN" weight="0.25"/>
+    <Model id="CB_14_BASIN" weight="0.25"/>
+    <Model id="CY_14_BASIN" weight="0.25"/>
   </ModelSet>
 </GroundMotionModels>


### PR DESCRIPTION
Removed _AMP suffix from GMMs; deep basin effects applied in the 2018 model are not strictly amplifying-only